### PR TITLE
Upgrade git version for centos 7, so we can use git --first-parent

### DIFF
--- a/Dockerfile-devcore-centos-6
+++ b/Dockerfile-devcore-centos-6
@@ -24,7 +24,7 @@ RUN wget "http://mirror.metrocast.net/apache/maven/maven-3/3.3.9/binaries/apache
 RUN wget "https://www.apache.org/dist/ant/binaries/apache-ant-1.9.13-bin.tar.gz"                          -O - | tar --no-same-owner -xzf - -C /home/build/.zm-dev-tools/
 
 # Use a newer git
-RUN yum install -y zlib-devel gettext
+RUN yum install -y zlib-devel gettext curl-devel
 RUN wget "https://www.kernel.org/pub/software/scm/git/git-2.9.5.tar.gz" -O - | tar --no-same-owner -xzf - -C /root
 RUN cd /root/git-2.9.5 && ./configure --without-tcltk
 RUN make -C /root/git-2.9.5

--- a/Dockerfile-devcore-centos-7
+++ b/Dockerfile-devcore-centos-7
@@ -18,6 +18,16 @@ RUN yum install -y rpm-build createrepo
 RUN useradd -ms /bin/bash -G wheel build
 RUN sed -i -e '/^%wheel/s/)\s*ALL$/) NOPASSWD: ALL/' /etc/sudoers
 
+# Use a newer git
+RUN yum install -y zlib-devel gettext curl-devel
+RUN wget "https://www.kernel.org/pub/software/scm/git/git-2.9.5.tar.gz" -O - | tar --no-same-owner -xzf - -C /root
+RUN cd /root/git-2.9.5 && ./configure --without-tcltk
+RUN make -C /root/git-2.9.5
+RUN make -C /root/git-2.9.5 install
+RUN yum erase -y zlib-devel gettext
+RUN yum erase -y git
+RUN rm -rf /root/git-2.9.5
+
 # REDUCE PRIVILEGE
 USER build
 WORKDIR /home/build


### PR DESCRIPTION
Fix issue in centos 6 where cloning a repo was giving error "Unable to find remote helper for 'https'"