### PR TITLE
ZCS-13922: Added Ubuntu 22 base image for building zimbra packages.

### DIFF
--- a/Dockerfile-devcore-ubuntu-22.04
+++ b/Dockerfile-devcore-ubuntu-22.04
@@ -1,0 +1,36 @@
+# vi:ft=dockerfile
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# SYSTEM
+RUN apt-get -qq update
+RUN apt-get -qq dist-upgrade -y
+RUN apt-get -qq autoremove -y
+RUN apt-get -qq install -y apt-utils
+RUN apt-get -qq install -y ca-certificates tzdata
+RUN apt-get -qq install -y curl wget
+RUN apt-get -qq install -y software-properties-common
+RUN apt-get -qq install -y apt-transport-https
+RUN apt-get -qq install -y sudo
+
+# ENVIRONMENT
+RUN apt-get -qq install -y git perl ruby pkg-config libidn11-dev libwww-perl libz-dev libaio-dev libncurses-dev libexpat-dev libpcre3-dev libperl-dev libpopt-dev libbz2-dev libtest-simple-perl libsocket6-perl libtest-inter-perl libtest-warn-perl libtest-deep-perl debhelper
+RUN apt-get update && apt-get -qq install -y lib32z1-dev libz-dev build-essential zlib*
+RUN apt-get -qq install -y openjdk-8-jdk ant ant-optional maven rsync
+RUN apt-get install -y locales locales-all
+RUN curl https://rclone.org/install.sh | sudo bash
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# USER
+RUN groupadd --gid 1000 build \
+    && useradd --uid 1000 --gid 1000 -m build \
+    && echo build ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/build \
+    && chmod 0440 /etc/sudoers.d/build \
+    && chown -R 1000:1000 /home/build
+
+USER build
+WORKDIR /home/build


### PR DESCRIPTION
**ZCS-13922: Added Ubuntu 22 base image for building zimbra packages.**
- New docker image for building ubuntu 22 packages with required libs.