### PR TITLE
ZCS-14752 : Update git for RHEL7

### DIFF
--- a/Dockerfile-devcore-centos-7
+++ b/Dockerfile-devcore-centos-7
@@ -8,12 +8,14 @@ RUN yum install -y curl wget which
 RUN yum install -y sudo
 
 # ENVIRONMENT
-RUN yum install -y git perl ruby
+RUN yum install -y perl ruby
 RUN yum install -y perl-Data-Dumper perl-IPC-Cmd
 RUN yum install -y gcc gcc-c++ make
 RUN yum install -y java-1.8.0-openjdk ant ant-junit maven
 RUN yum install -y rpm-build createrepo rsync
 RUN curl https://rclone.org/install.sh | sudo bash
+RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+RUN yum install -y git
 
 # USERS
 RUN useradd -ms /bin/bash -G wheel build

--- a/Dockerfile-devcore-centos-7
+++ b/Dockerfile-devcore-centos-7
@@ -14,7 +14,7 @@ RUN yum install -y gcc gcc-c++ make
 RUN yum install -y java-1.8.0-openjdk ant ant-junit maven
 RUN yum install -y rpm-build createrepo rsync
 RUN curl https://rclone.org/install.sh | sudo bash
-RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+RUN yum install -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
 RUN yum install -y git
 
 # USERS


### PR DESCRIPTION
For RHEL-7 zimbra-license-daemon package version is showing wrong. 

`zimbra-license-daemon-1.0.0.-1.r7.x86_64`

Commit-id is missing after `zimbra-license-daemon-1.0.0`. It should be like `zimbra-license-daemon-1.0.0.1705647653-1.r7.x86_64`

This is due to `git log --format=%at -1` is failing in the rhel-7 container while creating the package in circleci. This issue is due to circleci using blobless clone (https://discuss.circleci.com/t/product-update-speeding-up-code-checkout/50317) while cloning the repo. Git version of RHEL-7 not compatible with blobless approach. We need to upgrade git.